### PR TITLE
OSM Shapes: solve issues on failed reprojection

### DIFF
--- a/src/Gismo_OSM Shapes.py
+++ b/src/Gismo_OSM Shapes.py
@@ -663,6 +663,7 @@ def createShapesKeysValues(locationName, locationLatitudeD, locationLongitudeD, 
         if reprojectedShapefile == None:
             # reprojection failed
             
+            utils = MapWinGIS.UtilsClass()
             convertErrorNo = MapWinGIS.GlobalSettingsClass().GdalLastErrorNo
             convertErrorMsg = MapWinGIS.GlobalSettingsClass().GdalLastErrorMsg
             convertErrorType = MapWinGIS.GlobalSettingsClass().GdalLastErrorType
@@ -685,6 +686,7 @@ def createShapesKeysValues(locationName, locationLatitudeD, locationLongitudeD, 
                        " \n" + \
                        "Restart Rhino and Grasshopper (close them, then run again) and run this component again.\n" + \
                        "If this same message appears again open a new topic about it on: www.grasshopper3d.com/group/gismo/forum."
+            return None, None, None, validShapes, printMsg
     
     
     originPtProjected_meters = gismo_gis.projectedLocationCoordinates(locationLatitudeD, locationLongitudeD)  # in meters!


### PR DESCRIPTION
The OSM Shapes component failing reprojection results in a crash, giving no helpful error message. Defining the variable `util` solves the `NameError`, while the `return` statement allows the error message to be displayed instead of going on assuming a successful reprojection, which eventually crashes because `reprojectedShapefile` is `None`.

This only changes the Python file, as I don't know how the .ghuser files are generated for this project, but I'd be happy to do that if given any pointers!

Thanks!